### PR TITLE
Fix cabal descriptions

### DIFF
--- a/json-alt/json-alt.cabal
+++ b/json-alt/json-alt.cabal
@@ -6,21 +6,21 @@ description:         Parsing JSON with Aeson often requires decoding fields
                      that have more than one Haskell type.
                      .
                      So we have:
-                     ```
-                     data a :|: b = AltLeft a
-                                  | AltLeft b
-
-                     printIt = print . (fromJSON :: ByteString -> Int :|: Bool)
-                     main = do
-                       printIt "1"    -- AltLeft 1
-                       printIt "true" -- AltRight True
-                       printIt "null" -- errors!
-                     ```
+                     .
+                     > data a :|: b = AltLeft a
+                     >              | AltRight b
+                     >
+                     > printIt = print . (fromJSON :: ByteString -> Int :|: Bool)
+                     > main = do
+                     >   printIt "1"    -- AltLeft 1
+                     >   printIt "true" -- AltRight True
+                     >   printIt "null" -- errors!
+                     .
                      To generate types for larger JSON documents,
-                     you might use `json-autotype`.
+                     you might use @json-autotype@.
                      .
                      This is separate package so that users
-                     do not have to keep `json-autotype` as runtime
+                     do not have to keep @json-autotype@ as runtime
                      dependency.
                      .
                      See <https://github.com/mgajda/json-autotype>

--- a/json-autotype/json-autotype.cabal
+++ b/json-autotype/json-autotype.cabal
@@ -2,30 +2,29 @@
 name:                json-autotype
 version:             3.0.0
 synopsis:            Automatic type declaration for JSON input data
-description:         Generates datatype declarations with Aeson's `FromJSON` instances
-                     from a set of example ".json" files.
+description:         Generates datatype declarations with Aeson's 'Data.Aeson.FromJSON'
+                     instances from a set of example @.json@ files.
                      .
                      To get started you need to install the package,
-                     and run "json-autotype" binary on an input ".json" file.
+                     and run @json-autotype@ binary on an input @.json@ file.
                      That will generate a new Aeson-based JSON parser.
                      .
-                     "$ json-autotype input.json -o JSONTypes.hs"
+                     > $ json-autotype input.json -o JSONTypes.hs
                      .
                      Feel free to tweak the by changing types of the fields
-                      - any field type that is instance of `FromJSON` should work.
+                      — any field type that is instance of 'Data.Aeson.FromJSON' should work.
                      .
                      You may immediately test the parser by calling it as a script:
                      .
-                     "$ runghc JSONTypes.hs input.json"
+                     > $ runghc JSONTypes.hs input.json
                      .
                      One can now use multiple input files to generate better type description.
                      .
                      Now with Elm code generation support!
-                     (If you want your favourite programming language supported too -
+                     (If you want your favourite programming language supported too —
                      name your price and mail the author.)
                      .
-                     See introduction on  <https://github.com/mgajda/json-autotype>
-                     for details.
+                     See introduction on <https://github.com/mgajda/json-autotype> for details.
 homepage:            https://github.com/mgajda/json-autotype
 license:             BSD3
 license-file:        LICENSE


### PR DESCRIPTION
Both `json-alt` and `json-autotype` have formatting errors in their cabal descriptions (and also there's a typo in the `json-alt` one. This PR fixes those errors.