### PR TITLE
Correct escaping for reserved keywords

### DIFF
--- a/json-autotype/src/Data/Aeson/AutoType/CodeGen/HaskellFormat.hs
+++ b/json-autotype/src/Data/Aeson/AutoType/CodeGen/HaskellFormat.hs
@@ -141,7 +141,7 @@ newDecl identifier kvs = do attrs <- forM kvs $ \(k, v) -> do
     fieldDecls attrList = Text.intercalate ",\n" $ map fieldDecl attrList
     fieldDecl :: (Text, Text, Text, Bool) -> Text
     fieldDecl (_jsonName, haskellName, fType, _nullable) = Text.concat [
-                                                             "    ", haskellName, " :: ", fType]
+                                                             "    ", (escapeKeywords haskellName), " :: ", fType]
 
 addDecl decl = decls %%= (\ds -> ((), decl:ds))
 
@@ -161,7 +161,7 @@ normalizeFieldName identifier = escapeKeywords             .
                                 normalizeTypeName
 
 keywords ::  Set Text
-keywords = Set.fromList ["type", "data", "module", "class", "where", "let", "do"]
+keywords = Set.fromList ["kind", "type", "data", "module", "class", "where", "let", "do"]
 
 escapeKeywords ::  Text -> Text
 escapeKeywords k | k `Set.member` keywords = k `Text.append` "_"


### PR DESCRIPTION
This is solution for the issue [31](https://github.com/migamake/json-autotype/issues/31) related to the missing `TopLevel` construct.  If user adds argument ` -t Blah` it's prefixed correctly and issue not visible.

In provided example, after close examination of example `reddit.json` json file and making multiple test runs 
```json
{
  "kind": "Listing",
  "data": {
    "modhash": "",
    "dist": 26,
    "children": [
      {
        "kind": "t3",
        "data": {
          "approved_at_utc": null,
          "subreddit": "haskell",
          ...
        }
      }
    ],
    "after": "t3_cr80iz",
    "before": null
  }
}
```
I found that escaping Haskell keywords not full. More over it's not applied for the field declarations which led to several errors that avoided building `TopLevel` declaration. Notice `kind` keyword inside children array.

This fix adds
- `kind` keyword in the escaping mechanism
- applying keywords escaping for field declarations 