### PR TITLE
Allows aeson-1.5.*

### DIFF
--- a/json-alt/json-alt.cabal
+++ b/json-alt/json-alt.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 19e927c68148b07a0870a432d17ad15c8f6f75df71f4e364ddadafb365015dcb
+-- hash: ef37834afb0c3c59c5073b49f4a25dd9aed8b2fb1b110a81df0bc06806e9b28d
 
 name:                json-alt
 version:             1.0.0
@@ -57,6 +57,6 @@ library
       Paths_json_alt
   other-extensions: TemplateHaskell ScopedTypeVariables OverloadedStrings FlexibleInstances MultiParamTypeClasses DeriveDataTypeable DeriveGeneric RecordWildCards
   build-depends:
-      aeson >=1.2.1 && <1.5
+      aeson >=1.2.1 && <1.6
     , base >=4.3 && <5
   default-language: Haskell2010

--- a/json-alt/package.yaml
+++ b/json-alt/package.yaml
@@ -61,7 +61,7 @@ other-extensions:
 - RecordWildCards
 dependencies:
 - base >=4.3 && <5
-- aeson >=1.2.1 && <1.5
+- aeson >=1.2.1 && <1.6
 library:
   exposed-modules:
   - Data.Aeson.AutoType.Alternative

--- a/json-autotype/json-autotype.cabal
+++ b/json-autotype/json-autotype.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 84501bebdbe7dc6b9b7c5605df545eaae45695e21f180ea3fd68181f878acd0d
+-- hash: 7114033541049096a61f28e73ec35f17c25b4599f3fdebae1b0824ef4392782c
 
 name:                json-autotype
 version:             3.0.4
@@ -94,14 +94,14 @@ library
   build-depends:
       GenericPretty >=1.2 && <1.3
     , QuickCheck >=2.4 && <3.0
-    , aeson >=1.2.1 && <1.5
+    , aeson >=1.2.1 && <1.6
     , base >=4.3 && <5
     , containers >=0.3 && <0.7
     , data-default >=0.7 && <0.8
     , filepath >=1.3 && <1.5
     , hashable >=1.2 && <1.4
     , json-alt
-    , lens >=4.1 && <4.19
+    , lens >=4.1 && <4.20
     , mtl >=2.1 && <2.3
     , pretty >=1.1 && <1.3
     , process >=1.1 && <1.7
@@ -126,7 +126,7 @@ executable json-autotype
   other-extensions: TemplateHaskell ScopedTypeVariables OverloadedStrings FlexibleInstances MultiParamTypeClasses DeriveDataTypeable DeriveGeneric RecordWildCards
   build-depends:
       GenericPretty >=1.2 && <1.3
-    , aeson >=1.2.1 && <1.5
+    , aeson >=1.2.1 && <1.6
     , base >=4.3 && <5
     , bytestring >=0.9 && <0.11
     , containers >=0.3 && <0.7
@@ -134,7 +134,7 @@ executable json-autotype
     , hashable >=1.2 && <1.4
     , json-alt
     , json-autotype
-    , lens >=4.1 && <4.19
+    , lens >=4.1 && <4.20
     , mtl >=2.1 && <2.3
     , optparse-applicative >=0.12 && <1.0
     , pretty >=1.1 && <1.3
@@ -161,7 +161,7 @@ test-suite json-autotype-examples
   build-depends:
       GenericPretty >=1.2 && <1.3
     , QuickCheck >=2.4 && <3.0
-    , aeson >=1.2.1 && <1.5
+    , aeson >=1.2.1 && <1.6
     , base >=4.3 && <5
     , containers >=0.3 && <0.7
     , directory >=1.1 && <1.4
@@ -169,7 +169,7 @@ test-suite json-autotype-examples
     , hashable >=1.2 && <1.4
     , json-alt
     , json-autotype
-    , lens >=4.1 && <4.19
+    , lens >=4.1 && <4.20
     , mtl >=2.1 && <2.3
     , optparse-applicative >=0.11 && <1.0
     , pretty >=1.1 && <1.3
@@ -196,7 +196,7 @@ test-suite json-autotype-gen-test
   build-depends:
       GenericPretty >=1.2 && <1.3
     , QuickCheck >=2.4 && <3.0
-    , aeson >=1.2.1 && <1.5
+    , aeson >=1.2.1 && <1.6
     , base >=4.3 && <5
     , bytestring >=0.9 && <0.11
     , containers >=0.3 && <0.7
@@ -205,7 +205,7 @@ test-suite json-autotype-gen-test
     , hashable >=1.2 && <1.4
     , json-alt
     , json-autotype
-    , lens >=4.1 && <4.19
+    , lens >=4.1 && <4.20
     , mtl >=2.1 && <2.3
     , optparse-applicative >=0.12 && <1.0
     , pretty >=1.1 && <1.3
@@ -232,14 +232,14 @@ test-suite json-autotype-qc-test
   build-depends:
       GenericPretty >=1.2 && <1.3
     , QuickCheck >=2.4 && <3.0
-    , aeson >=1.2.1 && <1.5
+    , aeson >=1.2.1 && <1.6
     , base >=4.3 && <5
     , containers >=0.3 && <0.7
     , filepath >=1.3 && <1.5
     , hashable >=1.2 && <1.4
     , json-alt
     , json-autotype
-    , lens >=4.1 && <4.19
+    , lens >=4.1 && <4.20
     , mtl >=2.1 && <2.3
     , optparse-applicative >=0.12 && <1.0
     , pretty >=1.1 && <1.3

--- a/json-autotype/package.yaml
+++ b/json-autotype/package.yaml
@@ -66,7 +66,7 @@ other-extensions:
 dependencies:
 - base >=4.3 && <5
 - GenericPretty >=1.2 && <1.3
-- aeson >=1.2.1 && <1.5
+- aeson >=1.2.1 && <1.6
 - containers >=0.3 && <0.7
 - filepath >=1.3 && <1.5
 - hashable >=1.2 && <1.4


### PR DESCRIPTION
Just what it says on the tin, bumps `aeson` deps and regenerates the constituent `*.cabal` files based on the changes to their respective `package.yaml` files.